### PR TITLE
chore(deps): consolidate dependency updates & bump to v0.1.1

### DIFF
--- a/etc/webserver_requirements.txt
+++ b/etc/webserver_requirements.txt
@@ -14,7 +14,7 @@ h11==0.16.0
 httpcore==1.0.9
 httptools==0.6.4
 httpx==0.28.1
-idna==3.10
+idna==3.15
 Jinja2==3.1.6
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2

--- a/etc/webserver_requirements.txt
+++ b/etc/webserver_requirements.txt
@@ -27,7 +27,7 @@ pydantic==2.11.4
 pydantic_core==2.33.2
 Pygments==2.19.1
 python-dotenv==1.1.0
-python-multipart==0.0.20
+python-multipart==0.0.31
 PyYAML==6.0.2
 requests==2.33.0
 rich==14.0.0

--- a/etc/webserver_requirements.txt
+++ b/etc/webserver_requirements.txt
@@ -25,7 +25,7 @@ pihole6api==0.2.0
 pyclean==3.1.0
 pydantic==2.11.4
 pydantic_core==2.33.2
-Pygments==2.19.1
+Pygments==2.20.0
 python-dotenv==1.1.0
 python-multipart==0.0.20
 PyYAML==6.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "network-kill-switch"
-version = "0.1.0"
+version = "0.1.1"
 description = "Home Network Kill Switch"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
This Pull Request consolidates the following Dependabot updates and bumps the project version to `v0.1.1`:

- #28: Bump python-multipart from 0.0.20 to 0.0.31 in /etc
- #27: Bump idna from 3.10 to 3.15 in /etc
- #23: Bump pygments from 2.19.1 to 2.20.0 in /etc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates Dependabot updates and bumps the project to v0.1.1. Updates `etc/webserver_requirements.txt` to keep dependencies current.

- **Dependencies**
  - `idna`: 3.10 → 3.15
  - `Pygments`: 2.19.1 → 2.20.0
  - `python-multipart`: 0.0.20 → 0.0.31

<sup>Written for commit fcc024d83284fe394316036c0dafd73c458b056a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/5L-Labs/overlord-network-kill-switch/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

