### PR TITLE
docs: add engineering preferences and review process to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,51 @@
 # Overlord Network Kill Switch
 
+## Engineering Preferences
+
+These preferences shape all work on this project. Apply them before any other consideration.
+
+- **DRY is about knowledge, not just text** — Flag logic duplication aggressively, but tolerate structural duplication if sharing it creates premature coupling (WET is better than the wrong abstraction).
+- **Well-tested code is non-negotiable** — Test behavior, not implementation details. I prefer redundant coverage over missing edge cases, but ensure tests are resilient to refactoring.
+- **Target "Engineered Enough"** — Handle current requirements + immediate edge cases. **Apply YAGNI**: do not build for hypothetical future use cases. Abstract only when you see the pattern for the third time (Rule of Three).
+- **Err on the side of handling more edge cases, not fewer** — thoughtfulness > speed.
+- **Bias toward explicit over clever.**
+
+---
+
+## Review Process (Plan Mode)
+
+Before starting a review, you **MUST** ask:
+
+> **BIG CHANGE or SMALL CHANGE?**
+> 1. **BIG CHANGE**: Work through this interactively, one section at a time (Architecture → Code Quality → Tests → Performance) with at most 4 top issues in each section.
+> 2. **SMALL CHANGE**: Work through interactively ONE question per review section.
+
+### Review Sections
+
+Walk through these four sections **in order**, presenting one section at a time. Wait for user feedback before proceeding to the next.
+
+1. **Architecture review** — overall system design, component boundaries, dependency graph, coupling, data flow, scaling, security.
+2. **Code quality review** — organization, module structure, DRY violations, error handling patterns, missing edge cases, tech debt hotspots, and over/under-engineering relative to preferences.
+3. **Test review** — coverage gaps (unit, integration, e2e), test quality, assertion strength, missing edge cases, untested failure modes, and error paths.
+4. **Performance review** — N+1 queries, database access patterns, memory-usage concerns, caching opportunities, slow or high-complexity code paths.
+
+### Issue Format
+
+For every specific issue (bug, smell, design concern, or risk):
+
+- Describe the problem concretely, with file and line references.
+- Present 2-3 options, including "do nothing" where reasonable.
+- For each option, specify: implementation effort, risk, impact on other code, and **maintenance burden**.
+- Give an opinionated recommendation and why, mapped to the engineering preferences.
+- Explicitly ask whether the user agrees or wants a different direction before proceeding.
+
+**Formatting Rules**:
+- **NUMBER issues** (1, 2, 3...) and then give **LETTERS for options** (A, B, C...).
+- The recommended option must always be the 1st option (Option A).
+- When asking for selection, make sure each option clearly labels the issue NUMBER and option LETTER.
+
+---
+
 ## Project Overview
 
 A HomeKit-integrated network control system for parental controls and focus time management. Controls Pi-hole DNS filtering and Ubiquiti firewall rules via a FastAPI server.


### PR DESCRIPTION
## Summary

- Adds engineering preferences (DRY, YAGNI, Rule of Three, explicit-over-clever) to AGENTS.md
- Adds structured code review process with BIG/SMALL change classification and four-section review flow (Architecture, Code Quality, Tests, Performance)
- Standardizes issue formatting with numbered issues and lettered options

## Test plan

- [ ] Review AGENTS.md content for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds engineering preferences and a structured code review workflow to `AGENTS.md` to standardize how we build and review changes. Introduces BIG vs SMALL change flow and clear issue formatting to keep reviews focused and consistent.

- **New Features**
  - Engineering prefs: DRY (knowledge), well-tested code, YAGNI + Rule of Three, explicit > clever, bias for edge cases.
  - Review flow: classify change size; four steps in order—Architecture, Code Quality, Tests, Performance; interactive per section.
  - Issue format: number issues; letter options (A, B, C) incl. “do nothing” when reasonable; capture effort/risk/impact/maintenance; recommend Option A and confirm direction.

<sup>Written for commit 7bc2431278d22db0e61b2a529fc771e5e7c72ebe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/5L-Labs/overlord-network-kill-switch/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

